### PR TITLE
[Feat-6] 사용자 이메일인증 로직 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/weshare/server/ServerApplication.java
+++ b/src/main/java/com/weshare/server/ServerApplication.java
@@ -3,9 +3,11 @@ package com.weshare.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 public class ServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/weshare/server/common/config/SecurityConfig.java
+++ b/src/main/java/com/weshare/server/common/config/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
         // URL 별 권한 설정
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/v3/**","/swagger-ui/**","/logout","/reissue").permitAll() // 스웨거 전체 허용 (임시)
+                        .requestMatchers("/v3/**","/swagger-ui/**","/logout","/reissue","/user/email/certification/**").permitAll() // 스웨거 전체 허용 (임시)
                         .anyRequest().authenticated());
 
         // CORS 설졍

--- a/src/main/java/com/weshare/server/user/certification/controller/EmailCertificationController.java
+++ b/src/main/java/com/weshare/server/user/certification/controller/EmailCertificationController.java
@@ -39,6 +39,11 @@ public class EmailCertificationController {
         return ResponseEntity.status(response.getHttpStatus()).body(response);
     }
 
+    @Operation(
+            summary = "이메일 인증번호 인증 요청",
+            description = "입력된 이메일에 대한 인증 번호를 전송하여, 서버로 부터 이메일 인증을 받음"
+    )
+
     @PostMapping("/verify")
     public ResponseEntity<CertificationResponse> verifyEmailCertificationKey(@RequestBody EmailVerificationRequest dto){
         log.info("[EMAIL_CERTIFICATION_KEY_VERIFY_REQUEST] email_address : {}",dto.getEmail());

--- a/src/main/java/com/weshare/server/user/certification/controller/EmailCertificationController.java
+++ b/src/main/java/com/weshare/server/user/certification/controller/EmailCertificationController.java
@@ -1,0 +1,49 @@
+package com.weshare.server.user.certification.controller;
+
+import com.weshare.server.user.certification.dto.EmailRequest;
+import com.weshare.server.user.certification.dto.CertificationResponse;
+import com.weshare.server.user.certification.dto.EmailVerificationRequest;
+import com.weshare.server.user.certification.service.EmailCertificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/user/email/certification")
+public class EmailCertificationController {
+
+    private final EmailCertificationService emailCertificationService;
+
+    // 사용자 이메일 인증요청 처리 (인증객체 생성 및 저장)
+    @Operation(
+            summary = "이메일 인증번호 생성 요청",
+            description = "입력된 이메일에 대한 인증번호를 생성하여 DB에 저장함 (유효시간 3분)"
+    )
+
+    @PostMapping
+    public ResponseEntity<CertificationResponse> sendEmailCertificationKey(@RequestBody EmailRequest dto){
+        String emailAddress = dto.getEmail();
+        log.info("[EMAIL_CERTIFICATION_KEY_REQUEST] email_address : {}",emailAddress);
+        emailCertificationService.createCertificationKey(emailAddress);
+        emailCertificationService.sendCertificationEmail(emailAddress);
+        log.info("[EMAIL_CERTIFICATION_KEY_RESPONSE] email_address : {}",emailAddress);
+        CertificationResponse response = new CertificationResponse(HttpStatus.OK,"email_certification_request-200","이메일 인증번호 생성 & 발송 성공");
+        return ResponseEntity.status(response.getHttpStatus()).body(response);
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<CertificationResponse> verifyEmailCertificationKey(@RequestBody EmailVerificationRequest dto){
+        log.info("[EMAIL_CERTIFICATION_KEY_VERIFY_REQUEST] email_address : {}",dto.getEmail());
+        emailCertificationService.doCertificateEmail(dto.getEmail(),dto.getKey());
+        CertificationResponse response = new CertificationResponse(HttpStatus.OK,"email_certification-200","이메일 인증 성공");
+        return ResponseEntity.status(response.getHttpStatus()).body(response);
+    }
+}

--- a/src/main/java/com/weshare/server/user/certification/dto/CertificationResponse.java
+++ b/src/main/java/com/weshare/server/user/certification/dto/CertificationResponse.java
@@ -1,0 +1,10 @@
+package com.weshare.server.user.certification.dto;
+
+import com.weshare.server.common.dto.BaseResponse;
+import org.springframework.http.HttpStatus;
+
+public class CertificationResponse extends BaseResponse {
+    public CertificationResponse(HttpStatus httpStatus, String code, String message) {
+        super(httpStatus, code, message);
+    }
+}

--- a/src/main/java/com/weshare/server/user/certification/dto/EmailRequest.java
+++ b/src/main/java/com/weshare/server/user/certification/dto/EmailRequest.java
@@ -1,0 +1,12 @@
+package com.weshare.server.user.certification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailRequest {
+    private String email;
+}

--- a/src/main/java/com/weshare/server/user/certification/dto/EmailRequest.java
+++ b/src/main/java/com/weshare/server/user/certification/dto/EmailRequest.java
@@ -1,5 +1,7 @@
 package com.weshare.server.user.certification.dto;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +9,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+
+@Schema(description = "이메일 인증번호 전송 요청 DTO")
 public class EmailRequest {
+    @Schema(description = "이메일 주소", example = "user@example.com")
     private String email;
 }

--- a/src/main/java/com/weshare/server/user/certification/dto/EmailVerificationRequest.java
+++ b/src/main/java/com/weshare/server/user/certification/dto/EmailVerificationRequest.java
@@ -1,5 +1,6 @@
 package com.weshare.server.user.certification.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,10 @@ import org.springframework.boot.SpringApplicationRunListener;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(description = "이메일 인증 DTO")
 public class EmailVerificationRequest {
+    @Schema(description = "이메일 주소", example = "user@example.com")
     private String email;
+    @Schema(description = "해당 이메일로 전송된 인증 번호", example = "ABCDEF")
     private String key;
 }

--- a/src/main/java/com/weshare/server/user/certification/dto/EmailVerificationRequest.java
+++ b/src/main/java/com/weshare/server/user/certification/dto/EmailVerificationRequest.java
@@ -1,0 +1,14 @@
+package com.weshare.server.user.certification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.SpringApplicationRunListener;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmailVerificationRequest {
+    private String email;
+    private String key;
+}

--- a/src/main/java/com/weshare/server/user/certification/entity/UserEmailCertification.java
+++ b/src/main/java/com/weshare/server/user/certification/entity/UserEmailCertification.java
@@ -1,0 +1,47 @@
+package com.weshare.server.user.certification.entity;
+
+import com.weshare.server.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "user_email_certification_number")
+public class UserEmailCertification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, name = "email_address", unique = true)
+    private String emailAddress;
+
+    @Column(name = "certification_key")
+    private String certificationKey;
+
+    @Column(name = "expiration_date_time")
+    private LocalDateTime expirationDateTime;
+
+    @Builder
+    public UserEmailCertification(String emailAddress, String certificationKey, LocalDateTime expirationDateTime){
+        this.emailAddress = emailAddress;
+        this.certificationKey = certificationKey;
+        this.expirationDateTime = expirationDateTime;
+    }
+
+    public String changeCertificationKey(String certificationKey){
+        this.certificationKey = certificationKey;
+        return certificationKey;
+    }
+
+    public LocalDateTime changeExpireDateTime(LocalDateTime expirationDateTime){
+        this.expirationDateTime = expirationDateTime;
+        return expirationDateTime;
+    }
+}

--- a/src/main/java/com/weshare/server/user/certification/exception/EmailCertificationErrorResponse.java
+++ b/src/main/java/com/weshare/server/user/certification/exception/EmailCertificationErrorResponse.java
@@ -1,0 +1,11 @@
+package com.weshare.server.user.certification.exception;
+
+import com.weshare.server.common.dto.BaseResponse;
+import lombok.Getter;
+
+@Getter
+public class EmailCertificationErrorResponse extends BaseResponse {
+    public EmailCertificationErrorResponse(EmailCertificationException exception){
+        super(exception.getHttpStatus(), exception.getErrorCode(), exception.getMessage());
+    }
+}

--- a/src/main/java/com/weshare/server/user/certification/exception/EmailCertificationException.java
+++ b/src/main/java/com/weshare/server/user/certification/exception/EmailCertificationException.java
@@ -1,0 +1,11 @@
+package com.weshare.server.user.certification.exception;
+
+import com.weshare.server.common.exception.base.BaseException;
+import lombok.Getter;
+
+@Getter
+public class EmailCertificationException extends BaseException {
+    public EmailCertificationException(EmailCertificationExceptions exceptions){
+        super(exceptions.getErrorType(),exceptions.getErrorCode(),exceptions.getMessage());
+    }
+}

--- a/src/main/java/com/weshare/server/user/certification/exception/EmailCertificationExceptionHandler.java
+++ b/src/main/java/com/weshare/server/user/certification/exception/EmailCertificationExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.weshare.server.user.certification.exception;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@RestControllerAdvice
+@Order(1)
+public class EmailCertificationExceptionHandler {
+    @ExceptionHandler(EmailCertificationException.class)
+    public ResponseEntity<EmailCertificationErrorResponse> certificationErrorHandler(EmailCertificationException exception){
+        return ResponseEntity.status(exception.getHttpStatus()).body(new EmailCertificationErrorResponse(exception));
+    }
+
+}

--- a/src/main/java/com/weshare/server/user/certification/exception/EmailCertificationExceptions.java
+++ b/src/main/java/com/weshare/server/user/certification/exception/EmailCertificationExceptions.java
@@ -1,0 +1,21 @@
+package com.weshare.server.user.certification.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum EmailCertificationExceptions {
+    User_EMAIL_CERTIFICATION_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"USER-EMAIL-502","이메일 인증키 전송실패"),
+    User_EMAIL_CERTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST,"USER-EMAIL-404","인증 등록되지 않은 이메일 주소"),
+    USER_EMAIL_CERTIFICATION_FAILURE(HttpStatus.BAD_REQUEST,"USER-EMAIL-401","이메일 주소 인증 실패"),
+    USER_EMAIL_CERTIFICATION_EXPIRED(HttpStatus.BAD_REQUEST,"USER-EMAIL-401","만료된 이메일 인증")
+    ;
+
+    private final HttpStatus errorType;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/weshare/server/user/certification/repository/UserEmailCertificationRepository.java
+++ b/src/main/java/com/weshare/server/user/certification/repository/UserEmailCertificationRepository.java
@@ -1,0 +1,12 @@
+package com.weshare.server.user.certification.repository;
+
+import com.weshare.server.user.certification.entity.UserEmailCertification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserEmailCertificationRepository extends JpaRepository<UserEmailCertification,Long> {
+
+    Optional<UserEmailCertification> findByEmailAddress(String emailAddress);
+    Boolean existsByEmailAddress(String emailAddress);
+}

--- a/src/main/java/com/weshare/server/user/certification/service/EmailCertificationService.java
+++ b/src/main/java/com/weshare/server/user/certification/service/EmailCertificationService.java
@@ -1,0 +1,9 @@
+package com.weshare.server.user.certification.service;
+
+import com.weshare.server.user.certification.entity.UserEmailCertification;
+
+public interface EmailCertificationService {
+    UserEmailCertification createCertificationKey(String emailAddress); // 이메일에 따른 인증키 등록 메서드
+    void sendCertificationEmail(String emailAddress); // 인증 번호 이메일 전송 메서드
+    void doCertificateEmail(String emailAddress, String key); // 이메일에 대한 인증성공 여부 업데이트 메서드
+}

--- a/src/main/java/com/weshare/server/user/certification/service/EmailCertificationServiceImpl.java
+++ b/src/main/java/com/weshare/server/user/certification/service/EmailCertificationServiceImpl.java
@@ -1,0 +1,148 @@
+package com.weshare.server.user.certification.service;
+
+import com.weshare.server.user.certification.entity.UserEmailCertification;
+import com.weshare.server.user.certification.exception.EmailCertificationException;
+import com.weshare.server.user.certification.exception.EmailCertificationExceptions;
+import com.weshare.server.user.certification.repository.UserEmailCertificationRepository;
+import com.weshare.server.user.entity.User;
+import com.weshare.server.user.exception.UserException;
+import com.weshare.server.user.exception.UserExceptions;
+import com.weshare.server.user.repository.UserRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmailCertificationServiceImpl implements EmailCertificationService{
+    private final UserEmailCertificationRepository userEmailCertificationRepository;
+    private final UserRepository userRepository;
+    private final JavaMailSender mailSender;
+    @Value("${spring.mail.username}")
+    private String senderEmailAddress;
+
+    @Override
+    @Transactional
+    public UserEmailCertification createCertificationKey(String emailAddress) {
+
+        String certificationKey = generateRandomString(6); // 6자리 인증번호 생성
+
+        // 이미 이메일 인증번호가 존재하는 경우에는 인증 번호를 변경함
+        if(userEmailCertificationRepository.existsByEmailAddress(emailAddress)){
+            UserEmailCertification userEmailCertification = userEmailCertificationRepository.findByEmailAddress(emailAddress)
+                    .orElseThrow(()-> new EmailCertificationException(EmailCertificationExceptions.User_EMAIL_CERTIFICATION_NOT_FOUND));
+            userEmailCertification.changeCertificationKey(certificationKey);
+            userEmailCertification.changeExpireDateTime(LocalDateTime.now().plusMinutes(3));
+            return  userEmailCertification;
+        }
+
+        // 최초 인증 시도인 경우 -> UserEmailCertification 객체 생성및 DB 저장
+        UserEmailCertification userEmailCertification = UserEmailCertification.builder()
+                .emailAddress(emailAddress)
+                .certificationKey(certificationKey)
+                .expirationDateTime(LocalDateTime.now().plusMinutes(3))
+                .build();
+
+        userEmailCertificationRepository.save(userEmailCertification);
+        return  userEmailCertification;
+    }
+
+    // 이메일 인증번호 발송 메서드
+    @Override
+    @Async
+    public void sendCertificationEmail(String emailAddress) {
+        UserEmailCertification userEmailCertification = userEmailCertificationRepository.findByEmailAddress(emailAddress)
+                .orElseThrow(()-> new EmailCertificationException(EmailCertificationExceptions.User_EMAIL_CERTIFICATION_NOT_FOUND));
+        String certificationKey = userEmailCertification.getCertificationKey();
+        sendMail(emailAddress,certificationKey);
+    }
+
+    // 이메일 인증시도 메서드
+    @Override
+    @Transactional
+    public void doCertificateEmail(String emailAddress, String key) {
+        UserEmailCertification userEmailCertification = userEmailCertificationRepository.findByEmailAddress(emailAddress)
+                .orElseThrow(()-> new EmailCertificationException(EmailCertificationExceptions.User_EMAIL_CERTIFICATION_NOT_FOUND));
+
+        if(userEmailCertification.getCertificationKey().equals(key)){
+
+            // 만료된 이메일 인증 번호일 경우
+            if(userEmailCertification.getExpirationDateTime().isBefore(LocalDateTime.now())){
+                throw new EmailCertificationException(EmailCertificationExceptions.USER_EMAIL_CERTIFICATION_EXPIRED);
+            }
+
+            User user = userRepository.findByEmail(emailAddress).orElseThrow(()->new UserException(UserExceptions.USER_EMAIL_NOT_FOUND));
+            user.changeIsVerified(true); // 유저 엔티티의 is_certificated 필드를 true로 변경함
+            log.info("[EMAIL_CERTIFICATION_KEY_VALIDATION_SUCCESS] email_address : {}",user.getEmail());
+        }
+        else {
+            throw new EmailCertificationException(EmailCertificationExceptions.USER_EMAIL_CERTIFICATION_FAILURE);
+        }
+    }
+
+    private String generateRandomString(int length){
+        String upperCaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        String lowerCaseLetters = "abcdefghijklmnopqrstuvwxyz";
+        String specialCharacters = "#_-";
+
+        // 모든 가능한 문자를 하나의 문자열로 결합
+        String allChars = upperCaseLetters + lowerCaseLetters + specialCharacters;
+
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder();
+
+        // length 길이만큼 난수 문자열 생성
+        for (int i = 0; i < length; i++) {
+            int index = random.nextInt(allChars.length());
+            sb.append(allChars.charAt(index));
+        }
+        return sb.toString();
+    }
+
+    private void sendMail(String emailAddress, String certificationKey){
+
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+            helper.setFrom(senderEmailAddress);
+            helper.setTo(emailAddress);
+            helper.setSubject("[We share 이메일 인증번호]");
+
+            String htmlContent = "<html>" +
+                    "<body style='background-color: #cccccc !important; margin: 0; padding: 20px;'>" +
+                    "<div style='max-width: 600px; margin: auto; background-color: #2a475e; padding: 20px; border-radius: 8px; color: #c7d5e0; font-family: Arial, sans-serif;'>" +
+                    "<h2 style='margin-top: 0;'>이메일 인증</h2>" +
+                    "<p>아래 인증 코드를 입력하여 이메일 인증을 완료하세요.</p>" +
+                    "<p>" +
+                    "<strong style='font-size: 20px;'>인증코드:</strong><br>" +
+                    "<span style='font-size: 18px; background-color: #FF8C00; color: #ffffff; padding: 15px 25px; border-radius: 5px; display: inline-block; margin: 5px 0;'>" +
+                    certificationKey +
+                    "</span>" +
+                    "</p>" +
+                    "<p style='margin-top: 20px; margin-bottom: 20px;'>유효시간: 3분</p>" +
+                    "<p>이 메일은 계정 보안을 위해 발송되었습니다.</p>" +
+                    "</div>" +
+                    "</body>" +
+                    "</html>";
+
+            helper.setText(htmlContent, true);
+            mailSender.send(message);
+            log.info("[EMAIL_CERTIFICATION_KEY_SEND] email_address : {}",emailAddress);
+        }catch (MessagingException e){
+            throw new EmailCertificationException(EmailCertificationExceptions.User_EMAIL_CERTIFICATION_SEND_ERROR);
+        }
+
+    }
+}

--- a/src/main/java/com/weshare/server/user/entity/User.java
+++ b/src/main/java/com/weshare/server/user/entity/User.java
@@ -16,7 +16,7 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 20)
+    @Column(nullable = false, unique = true)
     private String username; //  서비스내에서의 사용자 이름
 
     @Column(nullable = false, length = 20)
@@ -24,6 +24,9 @@ public class User extends BaseTimeEntity {
 
     @Column(nullable = false, unique = true)
     private String email; // 사용자 이메일
+
+    @Column(nullable = false,name = "is_certificated")
+    private Boolean isCertificated;
 
     private String phoneNumber; // 사용자 전화번호
 
@@ -51,5 +54,10 @@ public class User extends BaseTimeEntity {
     public String changePhoneNumber(String phoneNumber){
         this.phoneNumber = phoneNumber;
         return phoneNumber;
+    }
+
+    public Boolean changeIsVerified(Boolean isCertificated){
+        this.isCertificated = isCertificated;
+        return isCertificated;
     }
 }

--- a/src/main/java/com/weshare/server/user/exception/UserErrorResponse.java
+++ b/src/main/java/com/weshare/server/user/exception/UserErrorResponse.java
@@ -1,0 +1,11 @@
+package com.weshare.server.user.exception;
+
+import com.weshare.server.common.exception.base.BaseErrorResponse;
+import lombok.Getter;
+
+@Getter
+public class UserErrorResponse extends BaseErrorResponse {
+    public UserErrorResponse(UserException exception){
+        super(exception.getHttpStatus(),exception.getErrorCode(),exception.getMessage());
+    }
+}

--- a/src/main/java/com/weshare/server/user/exception/UserException.java
+++ b/src/main/java/com/weshare/server/user/exception/UserException.java
@@ -1,0 +1,12 @@
+package com.weshare.server.user.exception;
+
+import com.weshare.server.common.exception.base.BaseException;
+import lombok.Getter;
+
+@Getter
+public class UserException extends BaseException {
+
+    public UserException(UserExceptions exceptions){
+        super(exceptions.getErrorType(),exceptions.getErrorCode(), exceptions.getMessage());
+    }
+}

--- a/src/main/java/com/weshare/server/user/exception/UserExceptionHandler.java
+++ b/src/main/java/com/weshare/server/user/exception/UserExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.weshare.server.user.exception;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Order(1)
+public class UserExceptionHandler {
+
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<UserErrorResponse> userExceptionErrorHandler(UserException exception){
+        return ResponseEntity.status(exception.getHttpStatus()).body(new UserErrorResponse(exception));
+    }
+}

--- a/src/main/java/com/weshare/server/user/exception/UserExceptions.java
+++ b/src/main/java/com/weshare/server/user/exception/UserExceptions.java
@@ -1,0 +1,20 @@
+package com.weshare.server.user.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum UserExceptions {
+
+    USERNAME_NOT_FOUND(HttpStatus.UNAUTHORIZED,"USER-401","일치하는 유저를 찾는데 실패하였습니다."),
+    USER_EMAIL_NOT_FOUND(HttpStatus.UNAUTHORIZED,"USER_EMAIL-401","일치하는 유저의 이메일을 찾는데 실패하였습니다.")
+    ;
+
+    private final HttpStatus errorType;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/weshare/server/user/jwt/exception/JWTExceptions.java
+++ b/src/main/java/com/weshare/server/user/jwt/exception/JWTExceptions.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @JsonFormat(shape = JsonFormat.Shape.OBJECT) // 필드 값을 JSON으로 변환
 public enum JWTExceptions {
+    NOT_VERIFIED_EMAIL_USER(HttpStatus.UNAUTHORIZED,"NOT_VERIFIED_EMAIL_USER-401","인증되지 않은 이메일 사용자 입니다."),
     NO_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,"NO_ACCESS_TOKEN-401","액세스 토큰이 존재하지 않습니다."),
     EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,"EXPIRED_ACCESS_TOKEN-401","액세스 토큰이 만료되었습니다."),
     NOT_A_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,"NOT_ACCESS_TOKEN-401","적절한 액세스 토큰이 아닙니다."),

--- a/src/main/java/com/weshare/server/user/jwt/filter/JWTFilter.java
+++ b/src/main/java/com/weshare/server/user/jwt/filter/JWTFilter.java
@@ -35,6 +35,7 @@ public class JWTFilter extends OncePerRequestFilter {
                 || path.equals("/swagger-ui/index.html")
                 || path.equals("/logout")
                 || path.equals("/reissue")
+                || path.startsWith("/user/email/certification")
                 || path.startsWith("/webjars/");
     }
 

--- a/src/main/java/com/weshare/server/user/jwt/oauthJwt/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/weshare/server/user/jwt/oauthJwt/service/CustomOAuth2UserService.java
@@ -51,6 +51,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         if (existData == null) {
 
             User user = new User(username,oAuth2Response.getName(),oAuth2Response.getEmail(),UserRole.ROLE_USER);
+            user.changeIsVerified(false); // 사용자 이메일 인증이 진행되지 않은 상태
             userRepository.save(user);
 
             UserDTO userDTO = new UserDTO();

--- a/src/main/java/com/weshare/server/user/repository/UserRepository.java
+++ b/src/main/java/com/weshare/server/user/repository/UserRepository.java
@@ -4,7 +4,10 @@ import com.weshare.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User,Long> {
     User findByUsername(String username);
+    Optional<User> findByEmail(String emailAddress);
 }


### PR DESCRIPTION
### 🚀 Pull Request 개요

사용자 이메일 인증로직 추가

---

### 🔍 관련 이슈

> 이 PR이 해결하는 이슈 번호를 명시해주세요.  
Feat-6

---

### 🔧 변경 사항

> 어떤 기능을 **추가/수정/삭제**했는지 체크해주세요.

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 성능 개선
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 기타 (설명 필요)

---

### 📋 상세 설명
1. user 엔티티의 username 필드 글자수 제한 해제
2. UserEmailCertification(user_email_certification_number) 엔티티 도입
3.  이메일 발송 구현 & 인증로직 도입
4. 이메일 인증 시도 URL 시큐리티 예외처리
---

### ✅ 테스트 방법

로컬테스트
---

### ⚠️ 주의사항

1. sendCertificationEmail 메서드의 비동기 처리
2. EmailCertificationServiceImpl 서비스 레이어

---

### 📎 참고 자료 (선택)

