### PR TITLE
[Feat-32] 물품교환 요청 승인

### DIFF
--- a/src/main/java/com/weshare/server/exchange/candidate/dto/ExchangeCandidatePostDto.java
+++ b/src/main/java/com/weshare/server/exchange/candidate/dto/ExchangeCandidatePostDto.java
@@ -9,8 +9,8 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 public class ExchangeCandidatePostDto {
-    private Long id;
-    private  String itemName;
+    private Long exchangeCandidatePostId;
+    private String itemName;
     private String itemDescription;
     private String itemCondition;
     private String categoryName;
@@ -18,8 +18,8 @@ public class ExchangeCandidatePostDto {
     private String writerNickname;
 
     @Builder
-    public ExchangeCandidatePostDto(Long id, String itemName, String itemDescription, String itemCondition, String categoryName, List<String> imageUrlList, String writerNickname) {
-        this.id = id;
+    public ExchangeCandidatePostDto(Long exchangeCandidatePostId, String itemName, String itemDescription, String itemCondition, String categoryName, List<String> imageUrlList, String writerNickname) {
+        this.exchangeCandidatePostId = exchangeCandidatePostId;
         this.itemName = itemName;
         this.itemDescription = itemDescription;
         this.itemCondition = itemCondition;

--- a/src/main/java/com/weshare/server/exchange/candidate/entity/ExchangeCandidatePost.java
+++ b/src/main/java/com/weshare/server/exchange/candidate/entity/ExchangeCandidatePost.java
@@ -53,4 +53,9 @@ public class ExchangeCandidatePost extends BaseTimeEntity {
         this.category = category;
         this.exchangeCandidateStatus = exchangeCandidateStatus;
     }
+
+    public ExchangeCandidatePost updateExchangeCandidateStatus(ExchangeCandidateStatus exchangeCandidateStatus){
+        this.exchangeCandidateStatus = exchangeCandidateStatus;
+        return this;
+    }
 }

--- a/src/main/java/com/weshare/server/exchange/candidate/repository/ExchangeCandidatePostRepository.java
+++ b/src/main/java/com/weshare/server/exchange/candidate/repository/ExchangeCandidatePostRepository.java
@@ -1,10 +1,22 @@
 package com.weshare.server.exchange.candidate.repository;
 
+import com.weshare.server.exchange.candidate.entity.ExchangeCandidateStatus;
 import com.weshare.server.exchange.entity.ExchangePost;
 import com.weshare.server.exchange.candidate.entity.ExchangeCandidatePost;
+import com.weshare.server.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ExchangeCandidatePostRepository extends JpaRepository<ExchangeCandidatePost,Long> {
+    @Query("""
+        SELECT c
+          FROM ExchangeCandidatePost c
+         WHERE c.exchangeCandidateStatus = :candidateStatus
+           AND c.user                = :requestingUser
+    """)
+    List<ExchangeCandidatePost> findAllCandidatePostsByExchangeCandidateStatusAndUser(@Param("candidateStatus") ExchangeCandidateStatus candidateStatus, @Param("requestingUser") User requestingUser
+    );
 }

--- a/src/main/java/com/weshare/server/exchange/candidate/service/ExchangeCandidatePostAggregateService.java
+++ b/src/main/java/com/weshare/server/exchange/candidate/service/ExchangeCandidatePostAggregateService.java
@@ -49,7 +49,7 @@ public class ExchangeCandidatePostAggregateService {
             // 각각의 엔티티에 대하여 이미지키를 찾아와 presigned URL 획득하기
             List<String> presignedUrlList = exchangeCandidatePostImageService.getImageKey(exchangeCandidatePost).stream().map(s3Service::getPresignedUrl).collect(Collectors.toList());
             ExchangeCandidatePostDto exchangeCandidatePostDto = ExchangeCandidatePostDto.builder()
-                    .id(exchangeCandidatePost.getId())
+                    .exchangeCandidatePostId(exchangeCandidatePost.getId())
                     .itemName(exchangeCandidatePost.getItemName())
                     .itemDescription(exchangeCandidatePost.getItemDescription())
                     .itemCondition(exchangeCandidatePost.getItemCondition().getDescription())

--- a/src/main/java/com/weshare/server/exchange/candidate/service/post/ExchangeCandidatePostService.java
+++ b/src/main/java/com/weshare/server/exchange/candidate/service/post/ExchangeCandidatePostService.java
@@ -12,4 +12,6 @@ public interface ExchangeCandidatePostService {
     ExchangeCandidatePost findByExchangeCandidateId(Long exchangeCandidateId);
     List<ExchangeCandidatePost> findAllByExchangeCandidateId(List<Long> exchangeCandidateIdList);
     List<ExchangeCandidatePost> getAllUserEnrolledExchangeCandidatePost(Long exchangePostId, CustomOAuth2User principal);
+
+    ExchangeCandidatePost changeCandidateStatusToClosed(ExchangeCandidatePost exchangeCandidatePost);
 }

--- a/src/main/java/com/weshare/server/exchange/candidate/service/post/ExchangeCandidatePostServiceImpl.java
+++ b/src/main/java/com/weshare/server/exchange/candidate/service/post/ExchangeCandidatePostServiceImpl.java
@@ -99,8 +99,7 @@ public class ExchangeCandidatePostServiceImpl implements ExchangeCandidatePostSe
     // 특정 사용자가 등록한 교환 후보 게시글 목록 조회
     public List<ExchangeCandidatePost> getAllUserEnrolledExchangeCandidatePost(Long exchangePostId, CustomOAuth2User principal) {
         User user = userRepository.findByUsername(principal.getUsername()).orElseThrow(()->new UserException(UserExceptions.USER_NOT_FOUND));
-        ExchangePost exchangePost = exchangePostRepository.findById(exchangePostId).orElseThrow(()-> new ExchangePostException(ExchangePostExceptions.NOT_EXIST_EXCHANGE_POST));
-        return exchangeProposalRepository.findAllCandidatePostsByPostAndCandidateOwner(exchangePost,user);
+        return exchangeCandidatePostRepository.findAllCandidatePostsByExchangeCandidateStatusAndUser(ExchangeCandidateStatus.AVAILABLE,user);
     }
 
     @Override

--- a/src/main/java/com/weshare/server/exchange/candidate/service/post/ExchangeCandidatePostServiceImpl.java
+++ b/src/main/java/com/weshare/server/exchange/candidate/service/post/ExchangeCandidatePostServiceImpl.java
@@ -102,4 +102,11 @@ public class ExchangeCandidatePostServiceImpl implements ExchangeCandidatePostSe
         ExchangePost exchangePost = exchangePostRepository.findById(exchangePostId).orElseThrow(()-> new ExchangePostException(ExchangePostExceptions.NOT_EXIST_EXCHANGE_POST));
         return exchangeProposalRepository.findAllCandidatePostsByPostAndCandidateOwner(exchangePost,user);
     }
+
+    @Override
+    @Transactional
+    //해당 후보품의 상태를 TRADED 로 변경
+    public ExchangeCandidatePost changeCandidateStatusToClosed(ExchangeCandidatePost exchangeCandidatePost) {
+        return exchangeCandidatePost.updateExchangeCandidateStatus(ExchangeCandidateStatus.TRADED);
+    }
 }

--- a/src/main/java/com/weshare/server/exchange/controller/ExchangePostController.java
+++ b/src/main/java/com/weshare/server/exchange/controller/ExchangePostController.java
@@ -75,7 +75,7 @@ public class ExchangePostController {
 
         // 조건에 맞는 물품교환 게시글이 존재하는 경우
         // 마지막 응답객체의 ID
-        Optional<Long> lastIdOpt = exchangePostDtoList.stream().map(ExchangePostDto::getId).reduce((first, second) -> second);
+        Optional<Long> lastIdOpt = exchangePostDtoList.stream().map(ExchangePostDto::getExchangePostId).reduce((first, second) -> second);
         Long lastId = lastIdOpt.orElseThrow(()-> new ExchangePostException(ExchangePostExceptions.NOT_EXIST_EXCHANGE_POST_ID));
         ExchangePostListResponse exchangePostListResponse = new ExchangePostListResponse(totalPostCount,exchangePostDtoList,lastId);
         return ResponseEntity.ok(exchangePostListResponse);

--- a/src/main/java/com/weshare/server/exchange/dto/ExchangePostDto.java
+++ b/src/main/java/com/weshare/server/exchange/dto/ExchangePostDto.java
@@ -1,6 +1,5 @@
 package com.weshare.server.exchange.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +10,7 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 public class ExchangePostDto {
-    private Long id;
+    private Long exchangePostId;
     private String itemName;
     private String itemCondition;
     private String postStatus;
@@ -24,8 +23,8 @@ public class ExchangePostDto {
     private Boolean isYours;
 
     @Builder
-    public ExchangePostDto(Long id, String itemName, String itemCondition, String postStatus, List<String> categoryName, LocalDateTime createdAt, Long likes, List<String> imageUrlList, Boolean isUserLiked, Long viewCount, Boolean isYours) {
-        this.id = id;
+    public ExchangePostDto(Long exchangePostId, String itemName, String itemCondition, String postStatus, List<String> categoryName, LocalDateTime createdAt, Long likes, List<String> imageUrlList, Boolean isUserLiked, Long viewCount, Boolean isYours) {
+        this.exchangePostId = exchangePostId;
         this.itemName = itemName;
         this.itemCondition = itemCondition;
         this.postStatus = postStatus;

--- a/src/main/java/com/weshare/server/exchange/dto/ExchangePostListResponse.java
+++ b/src/main/java/com/weshare/server/exchange/dto/ExchangePostListResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 @AllArgsConstructor
 @Getter
 public class ExchangePostListResponse {
-    private Integer totalPostCount;
+    private Integer totalExchangePostCount;
     private List<ExchangePostDto> exchangePostDtoList;
     private Long lastPostId;
 }

--- a/src/main/java/com/weshare/server/exchange/dto/ExchangePostResponse.java
+++ b/src/main/java/com/weshare/server/exchange/dto/ExchangePostResponse.java
@@ -12,6 +12,6 @@ import java.util.List;
 @Getter
 public class ExchangePostResponse {
     private ExchangePostDto exchangePostDto;
-    private Integer totalCandidatePostCount;
+    private Integer totalExchangeCandidatePostCount;
     private List<ExchangeCandidatePostDto> exchangeCandidatePostDtoList;
 }

--- a/src/main/java/com/weshare/server/exchange/entity/ExchangePost.java
+++ b/src/main/java/com/weshare/server/exchange/entity/ExchangePost.java
@@ -56,4 +56,9 @@ public class ExchangePost extends BaseTimeEntity {
         this.exchangePostStatus = exchangePostStatus;
     }
 
+    public ExchangePost updateExchangePostStatus(ExchangePostStatus exchangePostStatus){
+        this.exchangePostStatus = exchangePostStatus;
+        return this;
+    }
+
 }

--- a/src/main/java/com/weshare/server/exchange/exception/post/ExchangePostExceptions.java
+++ b/src/main/java/com/weshare/server/exchange/exception/post/ExchangePostExceptions.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ExchangePostExceptions {
     NOT_EXIST_EXCHANGE_POST(HttpStatus.BAD_REQUEST,"NOT_EXIST_EXCHANGE_POST_ID","존재하지 않는 물품교환 게시글 입니다."),
-    NOT_EXIST_EXCHANGE_POST_ID(HttpStatus.BAD_REQUEST,"NOT_EXIST_EXCHANGE_POST_ID","존재하지 않는 물품교환 게시글로 id값을 조회할수 없습니다..");
+    NOT_EXIST_EXCHANGE_POST_ID(HttpStatus.BAD_REQUEST,"NOT_EXIST_EXCHANGE_POST_ID","존재하지 않는 물품교환 게시글로 id값을 조회할수 없습니다."),
+    NOT_OPENED_EXCHANGE_POST(HttpStatus.BAD_REQUEST,"NOT_OPENED_EXCHANGE_POST-401","교환 진행이 불가능한 공개 물품교환 게시글 입니다.")
+    ;
 
     private final HttpStatus errorType;
     private final String errorCode;

--- a/src/main/java/com/weshare/server/exchange/proposal/controller/ExchangeProposalController.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/controller/ExchangeProposalController.java
@@ -49,4 +49,6 @@ public class ExchangeProposalController {
         return ResponseEntity.ok(exchangeProposalResponse);
     }
 
+
+
 }

--- a/src/main/java/com/weshare/server/exchange/proposal/controller/ExchangeProposalController.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/controller/ExchangeProposalController.java
@@ -2,6 +2,7 @@ package com.weshare.server.exchange.proposal.controller;
 
 import com.weshare.server.exchange.candidate.dto.ExchangeCandidatePostDto;
 import com.weshare.server.exchange.proposal.dto.CandidateResponse;
+import com.weshare.server.exchange.proposal.dto.ExchangeAcceptanceResponse;
 import com.weshare.server.exchange.proposal.dto.ExchangeProposalRequest;
 import com.weshare.server.exchange.proposal.dto.ExchangeProposalResponse;
 import com.weshare.server.exchange.proposal.service.ExchangeProposalAggregateService;
@@ -49,6 +50,14 @@ public class ExchangeProposalController {
         return ResponseEntity.ok(exchangeProposalResponse);
     }
 
-
+    @Operation(
+            summary = "물품교환 승인 API",
+            description = "공개 물품교환 게시글 ID와 후보 교환품 ID를 기준으로 공개 물품교환 게시글가 교환을 승인하는 API"
+    )
+    @GetMapping("/acceptances")
+    public ResponseEntity<ExchangeAcceptanceResponse> acceptExchange(@RequestParam("exchangePostId")Long exchangePostId, @RequestParam("exchangeCandidatePostId")Long exchangeCandidatePostId, @AuthenticationPrincipal CustomOAuth2User principal){
+        ExchangeAcceptanceResponse response =exchangeProposalAggregateService.acceptExchange(exchangePostId,exchangeCandidatePostId,principal);
+        return ResponseEntity.ok(response);
+    }
 
 }

--- a/src/main/java/com/weshare/server/exchange/proposal/dto/ExchangeAcceptanceResponse.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/dto/ExchangeAcceptanceResponse.java
@@ -1,0 +1,27 @@
+package com.weshare.server.exchange.proposal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ExchangeAcceptanceResponse {
+    private Long updatedExchangePostId;
+    private String updatedExchangePostStatus;
+    private Long updatedExchangeCandidatePostId;
+    private String updatedExchangeCandidatePostStatus;
+    private Long updatedExchangeProposalId;
+    private String updatedExchangeProposalStatus;
+
+    @Builder
+    public ExchangeAcceptanceResponse(Long updatedExchangePostId, String updatedExchangePostStatus, Long updatedExchangeCandidatePostId, String updatedExchangeCandidatePostStatus, Long updatedExchangeProposalId, String updatedExchangeProposalStatus) {
+        this.updatedExchangePostId = updatedExchangePostId;
+        this.updatedExchangePostStatus = updatedExchangePostStatus;
+        this.updatedExchangeCandidatePostId = updatedExchangeCandidatePostId;
+        this.updatedExchangeCandidatePostStatus = updatedExchangeCandidatePostStatus;
+        this.updatedExchangeProposalId = updatedExchangeProposalId;
+        this.updatedExchangeProposalStatus = updatedExchangeProposalStatus;
+    }
+}

--- a/src/main/java/com/weshare/server/exchange/proposal/dto/ExchangeProposalRequest.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/dto/ExchangeProposalRequest.java
@@ -11,5 +11,5 @@ import java.util.List;
 @Getter
 public class ExchangeProposalRequest {
     private Long targetExchangePostId;
-    private List<Long> exchangeCandidateIdList;
+    private List<Long> exchangeCandidatePostIdList;
 }

--- a/src/main/java/com/weshare/server/exchange/proposal/entity/ExchangeProposal.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/entity/ExchangeProposal.java
@@ -36,4 +36,10 @@ public class ExchangeProposal extends BaseTimeEntity{
         this.exchangeCandidatePost = exchangeCandidatePost;
         this.exchangeProposalStatus = exchangeProposalStatus;
     }
+
+    public ExchangeProposal updateExchangeProposalStatus(ExchangeProposalStatus exchangeProposalStatus){
+        this.exchangeProposalStatus = exchangeProposalStatus;
+        return this;
+    }
+
 }

--- a/src/main/java/com/weshare/server/exchange/proposal/exception/ExchangeProposalExceptions.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/exception/ExchangeProposalExceptions.java
@@ -14,7 +14,9 @@ public enum ExchangeProposalExceptions {
     ALREADY_CLOSED_EXCHANGE_POST(HttpStatus.BAD_REQUEST,"ALREADY_CLOSED_EXCHANGE_POST-401","이미 교환을 완료한 게시글로 더이상 교환을 제안할 수 없습니다."),
     ALREADY_PROPOSED_CANDIDATE_TO_THIS_EXCHANGE_POST(HttpStatus.BAD_REQUEST,"ALREADY_PROPOSED_CANDIDATE_TO_THIS_EXCHANGE_POST-401","이미 해당 게시물에 교환이 제안된 상품입니다."),
     NOT_A_CANDIDATE_POST_OWNER(HttpStatus.BAD_REQUEST,"NOT_A_CANDIDATE_POST_OWNER-401", "해당 물품교환 후보품의 등록자와 현재 서비스 요청자가 일치하지 않습니다."),
-    CANNOT_PROPOSE_YOURSELF(HttpStatus.BAD_REQUEST,"CANNOT_PROPOSE_YOURSELF-401","자기 자신이 작성한 제시글에 교환을 제안할 수 없습니다.");
+    CANNOT_PROPOSE_YOURSELF(HttpStatus.BAD_REQUEST,"CANNOT_PROPOSE_YOURSELF-401","자기 자신이 작성한 제시글에 교환을 제안할 수 없습니다."),
+    NOT_A_EXCHANGE_POST_WRITER(HttpStatus.BAD_REQUEST,"NOT_A_EXCHANGE_POST_WRITER-401","공개 물품 교환 게시글 작성자 본인이 아닙니다."),
+    FAILURE_FOR_ACCEPT_EXCHANGE_TARGET_SEARCH(HttpStatus.BAD_REQUEST,"FAILURE_FOR_ACCEPT_EXCHANGE_TARGET_SEARCH-401","물품교환 체결에 최종 실패하였습니다.");
 
     ;
 

--- a/src/main/java/com/weshare/server/exchange/proposal/repository/ExchangeProposalRepository.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/repository/ExchangeProposalRepository.java
@@ -1,6 +1,7 @@
 package com.weshare.server.exchange.proposal.repository;
 
 import com.weshare.server.exchange.candidate.entity.ExchangeCandidatePost;
+import com.weshare.server.exchange.candidate.entity.ExchangeCandidateStatus;
 import com.weshare.server.exchange.entity.ExchangePost;
 import com.weshare.server.exchange.proposal.entity.ExchangeProposal;
 import com.weshare.server.user.entity.User;
@@ -19,6 +20,6 @@ public interface ExchangeProposalRepository extends JpaRepository<ExchangePropos
     List<Long> findAlreadyProposedCandidatePostIds(@Param("targetExchangePostId") Long targetExchangePostId, @Param("exchangeCandidatePostIds") Collection<Long> exchangeCandidatePostIds
     );
 
-    @Query(" select proposal.exchangeCandidatePost from ExchangeProposal proposal where proposal.exchangePost = :targetExchangePost and proposal.exchangeCandidatePost.user = :requestingUser ")
-    List<ExchangeCandidatePost> findAllCandidatePostsByPostAndCandidateOwner(@Param("targetExchangePost") ExchangePost targetExchangePost, @Param("requestingUser") User requestingUser);
+//    @Query(" select proposal.exchangeCandidatePost from ExchangeProposal proposal where proposal.exchangePost = :targetExchangePost and proposal.exchangeCandidatePost.user = :requestingUser ")
+//    List<ExchangeCandidatePost> findAllCandidatePostsByPostAndCandidateOwner(@Param("targetExchangePost") ExchangePost targetExchangePost, @Param("requestingUser") User requestingUser);
 }

--- a/src/main/java/com/weshare/server/exchange/proposal/service/ExchangeProposalAggregateService.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/service/ExchangeProposalAggregateService.java
@@ -51,7 +51,7 @@ public class ExchangeProposalAggregateService {
             // 각각의 엔티티에 대하여 이미지키를 찾아와 presigned URL 획득하기
             List<String> presignedUrlList = exchangeCandidatePostImageService.getImageKey(exchangeCandidatePost).stream().map(s3Service::getPresignedUrl).collect(Collectors.toList());
             ExchangeCandidatePostDto exchangeCandidatePostDto = ExchangeCandidatePostDto.builder()
-                    .id(exchangeCandidatePost.getId())
+                    .exchangeCandidatePostId(exchangeCandidatePost.getId())
                     .itemName(exchangeCandidatePost.getItemName())
                     .itemDescription(exchangeCandidatePost.getItemDescription())
                     .itemCondition(exchangeCandidatePost.getItemCondition().getDescription())

--- a/src/main/java/com/weshare/server/exchange/proposal/service/ExchangeProposalAggregateService.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/service/ExchangeProposalAggregateService.java
@@ -83,7 +83,7 @@ public class ExchangeProposalAggregateService {
         }
 
         // 5) 교환 후보 아이템 일괄 조회
-        List<ExchangeCandidatePost> exchangeCandidatePostList = exchangeCandidatePostService.findAllByExchangeCandidateId(exchangeProposalRequest.getExchangeCandidateIdList());
+        List<ExchangeCandidatePost> exchangeCandidatePostList = exchangeCandidatePostService.findAllByExchangeCandidateId(exchangeProposalRequest.getExchangeCandidatePostIdList());
         List<Long> exchangeCandidatePostIdList = exchangeCandidatePostList.stream().map(ExchangeCandidatePost::getId).collect(Collectors.toList());
 
         // 6) 이미 제안된 후보 아이템 ID 배치 조회
@@ -122,7 +122,7 @@ public class ExchangeProposalAggregateService {
     public ExchangeProposalResponse doProposal(ExchangeProposalRequest request, CustomOAuth2User principal){
         User user = userService.findUserByUsername(principal.getUsername());
         ExchangePost exchangePost = exchangePostService.findExchangePost(request.getTargetExchangePostId());
-        List<ExchangeCandidatePost> exchangeCandidatePostList = exchangeCandidatePostService.findAllByExchangeCandidateId(request.getExchangeCandidateIdList());
+        List<ExchangeCandidatePost> exchangeCandidatePostList = exchangeCandidatePostService.findAllByExchangeCandidateId(request.getExchangeCandidatePostIdList());
 
         // 교환 요청자와 공개 교환 게시글 작성자가 동일인물인 경우
         if(Objects.equals(user.getId(), exchangePost.getUser().getId())){
@@ -157,7 +157,7 @@ public class ExchangeProposalAggregateService {
             exchangeProposalIdList.add(exchangeProposal.getId());
         }
 
-        ExchangeProposalResponse response = new ExchangeProposalResponse(true,exchangeProposalIdList, exchangePost.getId(), request.getExchangeCandidateIdList());
+        ExchangeProposalResponse response = new ExchangeProposalResponse(true,exchangeProposalIdList, exchangePost.getId(), request.getExchangeCandidatePostIdList());
         return response;
     }
 

--- a/src/main/java/com/weshare/server/exchange/proposal/service/ExchangeProposalAggregateService.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/service/ExchangeProposalAggregateService.java
@@ -160,5 +160,5 @@ public class ExchangeProposalAggregateService {
         ExchangeProposalResponse response = new ExchangeProposalResponse(true,exchangeProposalIdList, exchangePost.getId(), request.getExchangeCandidateIdList());
         return response;
     }
-    
+
 }

--- a/src/main/java/com/weshare/server/exchange/proposal/service/ExchangeProposalService.java
+++ b/src/main/java/com/weshare/server/exchange/proposal/service/ExchangeProposalService.java
@@ -13,4 +13,6 @@ public interface ExchangeProposalService {
     Boolean isAlreadyProposedCandidate(ExchangePost exchangePost, ExchangeCandidatePost exchangeCandidatePost);
 
     List<Long>findAlreadyProposedCandidatePostIdList(Long targetExchangePostId, Collection<Long> exchangeCandidatePostIds);
+
+    ExchangeProposal changeRelatedAllProposalsStatusToAcceptedAndRejected(ExchangePost exchangePost, ExchangeCandidatePost exchangeCandidatePost);
 }

--- a/src/main/java/com/weshare/server/exchange/service/ExchangePostAggregateService.java
+++ b/src/main/java/com/weshare/server/exchange/service/ExchangePostAggregateService.java
@@ -67,7 +67,7 @@ public class ExchangePostAggregateService {
             Long viewCount = exchangePostViewService.getViewCount(exchangePost.getId());
 
             ExchangePostDto exchangePostDto = ExchangePostDto.builder()
-                    .id(exchangePost.getId())
+                    .exchangePostId(exchangePost.getId())
                     .itemName(exchangePost.getItemName())
                     .itemCondition(exchangePost.getItemCondition().getDescription())
                     .postStatus(exchangePost.getExchangePostStatus().name())
@@ -99,7 +99,7 @@ public class ExchangePostAggregateService {
         Boolean isYours = exchangePostService.isPostWriter(exchangePost,principal);
 
         ExchangePostDto exchangePostDto = ExchangePostDto.builder()
-                .id(exchangePost.getId())
+                .exchangePostId(exchangePost.getId())
                 .itemName(exchangePost.getItemName())
                 .itemCondition(exchangePost.getItemCondition().getDescription())
                 .postStatus(exchangePost.getExchangePostStatus().name())

--- a/src/main/java/com/weshare/server/exchange/service/post/ExchangePostService.java
+++ b/src/main/java/com/weshare/server/exchange/service/post/ExchangePostService.java
@@ -14,4 +14,5 @@ public interface ExchangePostService {
     Long getLikeCount(ExchangePost exchangePost);
     Boolean isUserLikedPost(CustomOAuth2User principal, ExchangePost exchangePost);
     Boolean isPostWriter(ExchangePost exchangePost,CustomOAuth2User principal);
+    ExchangePost changeExchangePostStatusToClosed(ExchangePost exchangePost);
 }

--- a/src/main/java/com/weshare/server/exchange/service/post/ExchangePostServiceImpl.java
+++ b/src/main/java/com/weshare/server/exchange/service/post/ExchangePostServiceImpl.java
@@ -114,13 +114,21 @@ public class ExchangePostServiceImpl implements ExchangePostService{
     }
 
     @Override
+    @Transactional
     public ExchangePost findExchangePost(Long id) {
         return exchangePostRepository.findById(id).orElseThrow(()-> new ExchangePostException(ExchangePostExceptions.NOT_EXIST_EXCHANGE_POST));
     }
 
     @Override
+    @Transactional
     public Boolean isPostWriter(ExchangePost exchangePost, CustomOAuth2User principal) {
         User user = userRepository.findByUsername(principal.getUsername()).orElseThrow(()-> new UserException(UserExceptions.USER_NOT_FOUND));
         return Objects.equals(exchangePost.getUser().getId(), user.getId());
+    }
+
+    @Override
+    @Transactional
+    public ExchangePost changeExchangePostStatusToClosed(ExchangePost exchangePost) {
+        return exchangePost.updateExchangePostStatus(ExchangePostStatus.CLOSED);
     }
 }


### PR DESCRIPTION
### 🚀 Pull Request 개요

 물품교환 요청 승인

---

### 🔍 관련 이슈

Feat-32

---

### 🔧 변경 사항

> 어떤 기능을 **추가/수정/삭제**했는지 체크해주세요.

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 성능 개선
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 기타 (설명 필요)

---

### 📋 상세 설명

"/exchanges/proposal/acceptances?exchangePostId={exchangePostId}&exchangeCandidatePostId={exchangeCandidatePostId}"
로 exchangePost 작성자가 요청을 보내면 exchangePostId에 해당하는 exchangeCandidatePostId의 물품간의 교환 요청을 승인하는 API이다. 

이때
1. 물품교환 후보품 상태 TRADED로 변경하기
2. 공개 물품교환 게시글 상태 CLOSED로 변경하기
3. 거래가 성사된 exchangePost 와 ExchangeCandidatePost 가 담긴 ExchangeProposal 인스턴스의 상태 ACCEPTED로 변경하기 그외의 거래가 성사되지 못한 exchangePost 와 ExchangeCandidatePost 가 담긴 ExchangeProposal 인스턴스의 상태 REJECTED로 변경하기

로직이 순차적으로 실행되어 중복 거래를 방지한다.

---

### ✅ 테스트 방법

> 어떤 방식으로 테스트했는지 설명해주세요.  

포스트맨

---

### ⚠️ 주의사항

> 코드 리뷰 시 중점적으로 봐야 할 부분이나 공유하고 싶은 부분이 있다면 적어주세요.

---

### 📎 참고 자료 (선택)

<img width="850" height="920" alt="image" src="https://github.com/user-attachments/assets/22c7edce-9f81-4691-afe0-32941e75c9d6" />
