### PR TITLE
[Feat-35] 공동구매 물품등록 API 구현 완료

### DIFF
--- a/src/main/java/com/weshare/server/groupbuy/controller/GroupBuyPostController.java
+++ b/src/main/java/com/weshare/server/groupbuy/controller/GroupBuyPostController.java
@@ -1,0 +1,36 @@
+package com.weshare.server.groupbuy.controller;
+
+import com.weshare.server.groupbuy.dto.GroupBuyPostCreateRequest;
+import com.weshare.server.groupbuy.dto.GroupBuyPostCreateResponse;
+import com.weshare.server.groupbuy.service.GroupBuyAggregateService;
+import com.weshare.server.user.jwt.oauthJwt.dto.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/groupbuys")
+public class GroupBuyPostController {
+    private final GroupBuyAggregateService groupBuyAggregateService;
+
+    @Operation(
+            summary = "공동구매 게시글 등록 API",
+            description = "post로 게시글 정보를 images로 이미지 데이터를 받아 공동구매 게시글을 등록하는 API"
+    )
+    @PostMapping(value = "/posts",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<GroupBuyPostCreateResponse>createGroupBuyPost(@RequestPart("post") @Valid GroupBuyPostCreateRequest groupBuyPostCreateRequest, @RequestPart("images") List<MultipartFile> images, @AuthenticationPrincipal CustomOAuth2User principal ){
+        GroupBuyPostCreateResponse groupBuyPostCreateResponse= groupBuyAggregateService.createGroupBuyPost(groupBuyPostCreateRequest,images,principal);
+        return ResponseEntity.ok(groupBuyPostCreateResponse);
+    }
+}

--- a/src/main/java/com/weshare/server/groupbuy/dto/GroupBuyPostCreateRequest.java
+++ b/src/main/java/com/weshare/server/groupbuy/dto/GroupBuyPostCreateRequest.java
@@ -1,0 +1,44 @@
+package com.weshare.server.groupbuy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class GroupBuyPostCreateRequest {
+    @NotBlank
+    private String itemName;
+    @NotNull
+    private Long itemCategoryId;
+    @NotBlank
+    private String itemURL;
+    @NotBlank
+    private String itemDescription;
+    @NotNull
+    @JsonProperty("expirationDate")
+    private LocalDate expirationDate;
+    @NotNull
+    private Integer totalQuantity;
+    @NotNull
+    private Integer writerQuantity;
+    @NotNull
+    private Integer itemPrice;
+    @NotNull
+    private Integer shippingFee;
+    @NotNull
+    private Long locationId;
+
+    public static LocalDateTime dateToDateTimeWithEndOfDayTime(LocalDate localDate){
+        return localDate.atTime(23,59,59);
+    }
+}

--- a/src/main/java/com/weshare/server/groupbuy/dto/GroupBuyPostCreateResponse.java
+++ b/src/main/java/com/weshare/server/groupbuy/dto/GroupBuyPostCreateResponse.java
@@ -1,0 +1,13 @@
+package com.weshare.server.groupbuy.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupBuyPostCreateResponse {
+    private Boolean isSuccess;
+    private Long groupBuyPostId;
+}

--- a/src/main/java/com/weshare/server/groupbuy/entity/GroupBuyParticipant.java
+++ b/src/main/java/com/weshare/server/groupbuy/entity/GroupBuyParticipant.java
@@ -5,6 +5,7 @@ import com.weshare.server.payment.PaymentStatus;
 import com.weshare.server.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,4 +35,13 @@ public class GroupBuyParticipant extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_buy_post_id", nullable = false)
     private GroupBuyPost groupBuyPost;
+
+    @Builder
+    public GroupBuyParticipant(Integer quantity, Integer paymentAmount, PaymentStatus paymentStatus, User user, GroupBuyPost groupBuyPost) {
+        this.quantity = quantity;
+        this.paymentAmount = paymentAmount;
+        this.paymentStatus = paymentStatus;
+        this.user = user;
+        this.groupBuyPost = groupBuyPost;
+    }
 }

--- a/src/main/java/com/weshare/server/groupbuy/entity/GroupBuyPost.java
+++ b/src/main/java/com/weshare/server/groupbuy/entity/GroupBuyPost.java
@@ -7,6 +7,7 @@ import com.weshare.server.user.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -56,4 +57,17 @@ public class GroupBuyPost extends BaseTimeEntity {
     @JoinColumn(name = "location_id", nullable = false)
     private Location location;
 
+    @Builder
+    public GroupBuyPost(String itemName, String itemDescription, String itemUrl, Integer itemQuantity, Integer itemPrice, Integer shippingFee, LocalDateTime recruitingExpirationDate, User user, Category category, Location location) {
+        this.itemName = itemName;
+        this.itemDescription = itemDescription;
+        this.itemUrl = itemUrl;
+        this.itemQuantity = itemQuantity;
+        this.itemPrice = itemPrice;
+        this.shippingFee = shippingFee;
+        this.recruitingExpirationDate = recruitingExpirationDate;
+        this.user = user;
+        this.category = category;
+        this.location = location;
+    }
 }

--- a/src/main/java/com/weshare/server/groupbuy/entity/GroupBuyPostImage.java
+++ b/src/main/java/com/weshare/server/groupbuy/entity/GroupBuyPostImage.java
@@ -3,6 +3,7 @@ package com.weshare.server.groupbuy.entity;
 import com.weshare.server.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,4 +22,10 @@ public class GroupBuyPostImage extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_buy_post_id", nullable = false)
     private GroupBuyPost groupBuyPost;
+
+    @Builder
+    public GroupBuyPostImage(String groupBuyPostImageKey, GroupBuyPost groupBuyPost) {
+        this.groupBuyPostImageKey = groupBuyPostImageKey;
+        this.groupBuyPost = groupBuyPost;
+    }
 }

--- a/src/main/java/com/weshare/server/groupbuy/exception/GroupBuyPostErrorHandler.java
+++ b/src/main/java/com/weshare/server/groupbuy/exception/GroupBuyPostErrorHandler.java
@@ -1,0 +1,16 @@
+package com.weshare.server.groupbuy.exception;
+
+import com.weshare.server.exchange.exception.post.ExchangePostErrorResponse;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Order(1)
+public class GroupBuyPostErrorHandler {
+    @ExceptionHandler(GroupBuyPostException.class)
+    public ResponseEntity<GroupBuyPostErrorResponse> groupBuyPostErrorHandler(GroupBuyPostException exception){
+        return ResponseEntity.status(exception.getHttpStatus()).body(new GroupBuyPostErrorResponse(exception));
+    }
+}

--- a/src/main/java/com/weshare/server/groupbuy/exception/GroupBuyPostErrorResponse.java
+++ b/src/main/java/com/weshare/server/groupbuy/exception/GroupBuyPostErrorResponse.java
@@ -1,0 +1,9 @@
+package com.weshare.server.groupbuy.exception;
+
+import com.weshare.server.common.exception.base.BaseErrorResponse;
+
+public class GroupBuyPostErrorResponse extends BaseErrorResponse {
+    public GroupBuyPostErrorResponse(GroupBuyPostException exception){
+        super(exception.getHttpStatus(),exception.getErrorCode(),exception.getMessage());
+    }
+}

--- a/src/main/java/com/weshare/server/groupbuy/exception/GroupBuyPostException.java
+++ b/src/main/java/com/weshare/server/groupbuy/exception/GroupBuyPostException.java
@@ -1,0 +1,11 @@
+package com.weshare.server.groupbuy.exception;
+
+import com.weshare.server.common.exception.base.BaseException;
+import lombok.Getter;
+
+@Getter
+public class GroupBuyPostException extends BaseException {
+    public GroupBuyPostException(GroupBuyPostExceptions exceptions){
+        super(exceptions.getErrorType(),exceptions.getErrorCode(), exceptions.getMessage());
+    }
+}

--- a/src/main/java/com/weshare/server/groupbuy/exception/GroupBuyPostExceptions.java
+++ b/src/main/java/com/weshare/server/groupbuy/exception/GroupBuyPostExceptions.java
@@ -1,0 +1,17 @@
+package com.weshare.server.groupbuy.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum GroupBuyPostExceptions {
+    EXPIRATION_DATE_EARLY_ERROR(HttpStatus.BAD_REQUEST,"EXPIRATION_DATE_ERROR-401","모집 마감일이 금일보다 빠를수는 없습니다."),
+    ;
+    private final HttpStatus errorType;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/weshare/server/groupbuy/repository/GroupBuyParticipantRepository.java
+++ b/src/main/java/com/weshare/server/groupbuy/repository/GroupBuyParticipantRepository.java
@@ -1,0 +1,7 @@
+package com.weshare.server.groupbuy.repository;
+
+import com.weshare.server.groupbuy.entity.GroupBuyParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupBuyParticipantRepository extends JpaRepository<GroupBuyParticipant,Long> {
+}

--- a/src/main/java/com/weshare/server/groupbuy/repository/GroupBuyPostImageRepository.java
+++ b/src/main/java/com/weshare/server/groupbuy/repository/GroupBuyPostImageRepository.java
@@ -1,0 +1,11 @@
+package com.weshare.server.groupbuy.repository;
+
+import com.weshare.server.groupbuy.entity.GroupBuyPost;
+import com.weshare.server.groupbuy.entity.GroupBuyPostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GroupBuyPostImageRepository extends JpaRepository<GroupBuyPostImage,Long> {
+    List<GroupBuyPostImage> findAllByGroupBuyPost(GroupBuyPost groupBuyPost);
+}

--- a/src/main/java/com/weshare/server/groupbuy/repository/GroupBuyPostRepository.java
+++ b/src/main/java/com/weshare/server/groupbuy/repository/GroupBuyPostRepository.java
@@ -1,0 +1,8 @@
+package com.weshare.server.groupbuy.repository;
+
+import com.weshare.server.groupbuy.dto.GroupBuyPostCreateRequest;
+import com.weshare.server.groupbuy.entity.GroupBuyPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupBuyPostRepository extends JpaRepository<GroupBuyPost,Long> {
+}

--- a/src/main/java/com/weshare/server/groupbuy/service/GroupBuyAggregateService.java
+++ b/src/main/java/com/weshare/server/groupbuy/service/GroupBuyAggregateService.java
@@ -1,0 +1,42 @@
+package com.weshare.server.groupbuy.service;
+
+import com.weshare.server.aws.s3.service.S3Service;
+import com.weshare.server.groupbuy.dto.GroupBuyPostCreateRequest;
+import com.weshare.server.groupbuy.dto.GroupBuyPostCreateResponse;
+import com.weshare.server.groupbuy.entity.GroupBuyParticipant;
+import com.weshare.server.groupbuy.entity.GroupBuyPost;
+import com.weshare.server.groupbuy.service.image.GroupBuyPostImageService;
+import com.weshare.server.groupbuy.service.participant.GroupBuyParticipantService;
+import com.weshare.server.groupbuy.service.post.GroupBuyPostService;
+import com.weshare.server.user.jwt.oauthJwt.dto.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GroupBuyAggregateService {
+    private final GroupBuyPostService groupBuyPostService;
+    private final GroupBuyParticipantService groupBuyParticipantService;
+    private final GroupBuyPostImageService groupBuyPostImageService;
+    private final S3Service s3Service;
+    private static final String directory = "groupBuy";
+
+    @Transactional
+    public GroupBuyPostCreateResponse createGroupBuyPost(GroupBuyPostCreateRequest groupBuyPostCreateRequest, List<MultipartFile> images, CustomOAuth2User principal){
+        // GroupBuyPost 게시글 등록하기
+         GroupBuyPost groupBuyPost = groupBuyPostService.createGroupBuyPost(groupBuyPostCreateRequest,principal);
+        //GroupBuyPostImage 등록하기
+        for(MultipartFile img : images){
+            String key = s3Service.uploadImage(directory,img);
+            groupBuyPostImageService.saveImageKey(key,groupBuyPost);
+        }
+        //GroupBuyParticipant 등록하기
+        groupBuyParticipantService.addPostOwner(groupBuyPost,groupBuyPostCreateRequest.getWriterQuantity(),principal);
+
+        return new GroupBuyPostCreateResponse(true,groupBuyPost.getId());
+    }
+}

--- a/src/main/java/com/weshare/server/groupbuy/service/image/GroupBuyPostImageService.java
+++ b/src/main/java/com/weshare/server/groupbuy/service/image/GroupBuyPostImageService.java
@@ -1,0 +1,13 @@
+package com.weshare.server.groupbuy.service.image;
+
+import com.weshare.server.groupbuy.entity.GroupBuyPost;
+import com.weshare.server.groupbuy.entity.GroupBuyPostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GroupBuyPostImageService {
+    GroupBuyPostImage saveImageKey(String key, GroupBuyPost groupBuyPost);
+    List<String> getImageKey(GroupBuyPost groupBuyPost);
+
+}

--- a/src/main/java/com/weshare/server/groupbuy/service/image/GroupBuyPostImageServiceImpl.java
+++ b/src/main/java/com/weshare/server/groupbuy/service/image/GroupBuyPostImageServiceImpl.java
@@ -1,0 +1,41 @@
+package com.weshare.server.groupbuy.service.image;
+
+import com.weshare.server.groupbuy.entity.GroupBuyPost;
+import com.weshare.server.groupbuy.entity.GroupBuyPostImage;
+import com.weshare.server.groupbuy.repository.GroupBuyPostImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GroupBuyPostImageServiceImpl implements GroupBuyPostImageService{
+    private final GroupBuyPostImageRepository groupBuyPostImageRepository;
+    @Override
+    @Transactional
+    public GroupBuyPostImage saveImageKey(String key, GroupBuyPost groupBuyPost) {
+        GroupBuyPostImage groupBuyPostImage = GroupBuyPostImage.builder()
+                .groupBuyPostImageKey(key)
+                .groupBuyPost(groupBuyPost)
+                .build();
+        return groupBuyPostImageRepository.save(groupBuyPostImage);
+    }
+
+    @Override
+    @Transactional
+    public List<String> getImageKey(GroupBuyPost groupBuyPost) {
+        // 해당 공동구매 게시글에 등록된 모든 이미지 엔티티 가져오기
+        List<GroupBuyPostImage> groupBuyPostImageList = groupBuyPostImageRepository.findAllByGroupBuyPost(groupBuyPost);
+
+        // 이미지 키 추출
+        List<String> keyList = new ArrayList<>();
+        for(GroupBuyPostImage groupBuyPostImage : groupBuyPostImageList){
+            String key = groupBuyPostImage.getGroupBuyPostImageKey();
+            keyList.add(key);
+        }
+        return keyList;
+    }
+}

--- a/src/main/java/com/weshare/server/groupbuy/service/participant/GroupBuyParticipantService.java
+++ b/src/main/java/com/weshare/server/groupbuy/service/participant/GroupBuyParticipantService.java
@@ -1,0 +1,11 @@
+package com.weshare.server.groupbuy.service.participant;
+
+import com.weshare.server.groupbuy.entity.GroupBuyParticipant;
+import com.weshare.server.groupbuy.entity.GroupBuyPost;
+import com.weshare.server.user.entity.User;
+import com.weshare.server.user.jwt.oauthJwt.dto.CustomOAuth2User;
+
+public interface GroupBuyParticipantService {
+    GroupBuyParticipant addParticipant(User user, GroupBuyPost groupBuyPost,Integer quantity);
+    GroupBuyParticipant addPostOwner(GroupBuyPost groupBuyPost, Integer quantity, CustomOAuth2User principal);
+}

--- a/src/main/java/com/weshare/server/groupbuy/service/participant/GroupBuyParticipantServiceImpl.java
+++ b/src/main/java/com/weshare/server/groupbuy/service/participant/GroupBuyParticipantServiceImpl.java
@@ -1,0 +1,37 @@
+package com.weshare.server.groupbuy.service.participant;
+
+import com.weshare.server.groupbuy.entity.GroupBuyParticipant;
+import com.weshare.server.groupbuy.entity.GroupBuyPost;
+import com.weshare.server.groupbuy.repository.GroupBuyParticipantRepository;
+import com.weshare.server.payment.PaymentStatus;
+import com.weshare.server.user.entity.User;
+import com.weshare.server.user.exception.UserException;
+import com.weshare.server.user.exception.UserExceptions;
+import com.weshare.server.user.jwt.oauthJwt.dto.CustomOAuth2User;
+import com.weshare.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupBuyParticipantServiceImpl implements GroupBuyParticipantService{
+    private final UserRepository userRepository;
+    private final GroupBuyParticipantRepository groupBuyParticipantRepository;
+    @Override
+    public GroupBuyParticipant addParticipant(User user, GroupBuyPost groupBuyPost, Integer quantity) {
+        return null;
+    }
+
+    @Override
+    public GroupBuyParticipant addPostOwner(GroupBuyPost groupBuyPost, Integer quantity, CustomOAuth2User principal) {
+        User user = userRepository.findByUsername(principal.getUsername()).orElseThrow(()-> new UserException(UserExceptions.USER_NOT_FOUND));
+        GroupBuyParticipant groupBuyParticipant = GroupBuyParticipant.builder()
+                .user(user)
+                .groupBuyPost(groupBuyPost)
+                .paymentAmount(0)
+                .paymentStatus(PaymentStatus.POST_OWNER)
+                .quantity(quantity)
+                .build();
+        return groupBuyParticipantRepository.save(groupBuyParticipant);
+    }
+}

--- a/src/main/java/com/weshare/server/groupbuy/service/post/GroupBuyPostService.java
+++ b/src/main/java/com/weshare/server/groupbuy/service/post/GroupBuyPostService.java
@@ -1,0 +1,9 @@
+package com.weshare.server.groupbuy.service.post;
+
+import com.weshare.server.groupbuy.dto.GroupBuyPostCreateRequest;
+import com.weshare.server.groupbuy.entity.GroupBuyPost;
+import com.weshare.server.user.jwt.oauthJwt.dto.CustomOAuth2User;
+
+public interface GroupBuyPostService {
+    GroupBuyPost createGroupBuyPost(GroupBuyPostCreateRequest request, CustomOAuth2User principal);
+}

--- a/src/main/java/com/weshare/server/groupbuy/service/post/GroupBuyPostServiceImpl.java
+++ b/src/main/java/com/weshare/server/groupbuy/service/post/GroupBuyPostServiceImpl.java
@@ -1,0 +1,63 @@
+package com.weshare.server.groupbuy.service.post;
+
+import com.weshare.server.category.entity.Category;
+import com.weshare.server.category.exception.CategoryException;
+import com.weshare.server.category.exception.CategoryExceptions;
+import com.weshare.server.category.repository.CategoryRepository;
+import com.weshare.server.groupbuy.dto.GroupBuyPostCreateRequest;
+import com.weshare.server.groupbuy.entity.GroupBuyPost;
+import com.weshare.server.groupbuy.exception.GroupBuyPostException;
+import com.weshare.server.groupbuy.exception.GroupBuyPostExceptions;
+import com.weshare.server.groupbuy.repository.GroupBuyPostRepository;
+import com.weshare.server.location.entity.Location;
+import com.weshare.server.location.exception.LocationException;
+import com.weshare.server.location.exception.LocationExceptions;
+import com.weshare.server.location.repository.LocationRepository;
+import com.weshare.server.user.entity.User;
+import com.weshare.server.user.exception.UserException;
+import com.weshare.server.user.exception.UserExceptions;
+import com.weshare.server.user.jwt.oauthJwt.dto.CustomOAuth2User;
+import com.weshare.server.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class GroupBuyPostServiceImpl implements GroupBuyPostService{
+    private final UserRepository userRepository;
+    private final LocationRepository locationRepository;
+    private final CategoryRepository categoryRepository;
+    private final GroupBuyPostRepository groupBuyPostRepository;
+
+    @Override
+    @Transactional
+    public GroupBuyPost createGroupBuyPost(GroupBuyPostCreateRequest request, CustomOAuth2User principal) {
+
+        User user = userRepository.findByUsername(principal.getUsername()).orElseThrow(()-> new UserException(UserExceptions.USER_NOT_FOUND));
+        Location location = locationRepository.findById(request.getLocationId()).orElseThrow(()-> new LocationException(LocationExceptions.NOT_EXIST_LOCATION_ID));
+        Category category = categoryRepository.findById(request.getItemCategoryId()).orElseThrow(()-> new CategoryException(CategoryExceptions.NOT_EXIST_CATEGORY_ID));
+
+        // 예외처리 (입력으로 들어온 마감 날짜가 오늘보다 이른 경우 )
+        if(request.getExpirationDate().isBefore(LocalDate.now())){
+            throw new GroupBuyPostException(GroupBuyPostExceptions.EXPIRATION_DATE_EARLY_ERROR);
+        }
+
+        GroupBuyPost groupBuyPost = GroupBuyPost.builder()
+                .itemName(request.getItemName())
+                .itemDescription(request.getItemDescription())
+                .itemUrl(request.getItemURL())
+                .itemQuantity(request.getTotalQuantity())
+                .itemPrice(request.getItemPrice())
+                .shippingFee(request.getShippingFee())
+                .recruitingExpirationDate(GroupBuyPostCreateRequest.dateToDateTimeWithEndOfDayTime(request.getExpirationDate()))
+                .user(user)
+                .category(category)
+                .location(location)
+                .build();
+
+        return groupBuyPostRepository.save(groupBuyPost);
+    }
+}

--- a/src/main/java/com/weshare/server/payment/PaymentStatus.java
+++ b/src/main/java/com/weshare/server/payment/PaymentStatus.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum PaymentStatus {
-
+    POST_OWNER("공동구매 진행자 예외"),
     PENDING("결제 대기"),
     PAID("결제 완료"),
     CANCELED("결제 취소");


### PR DESCRIPTION
### 🚀 Pull Request 개요

 공동구매 물품등록 API 구현

---

### 🔍 관련 이슈

Feat-35

---

### 🔧 변경 사항

> 어떤 기능을 **추가/수정/삭제**했는지 체크해주세요.

- [x] 새로운 기능 추가
- [ ] 기존 기능 개선
- [ ] 성능 개선
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 기타 (설명 필요)

---

### 📋 상세 설명

post:

{
  "itemName": "string",
  "itemCategoryId": 0,
  "itemURL": "string",
  "itemDescription": "string",
  "totalQuantity": 0,
  "writerQuantity": 0,
  "itemPrice": 0,
  "shippingFee": 0,
  "locationId": 0,
  "expirationDate": "2025-08-06"
}

images : 이미지 데이터

를 멀티파트 입력으로 받아서 

group_buy_post
group_buy_post_image
group_buy_post_participant 테이블 들에 각각 게시글 정보, 이미지 키, 거래 정보를 저장한다.

응답: 
{
  "isSuccess": true,
  "groupBuyPostId": 0
}


---

### ✅ 테스트 방법

포스트맨
---

### ⚠️ 주의사항

> 코드 리뷰 시 중점적으로 봐야 할 부분이나 공유하고 싶은 부분이 있다면 적어주세요.

---

### 📎 참고 자료 (선택)

> 관련 문서, 참고 링크, 이슈, 스크린샷 등이 있다면 여기에 첨부해주세요.
